### PR TITLE
Datetime microsecond precision

### DIFF
--- a/src/schema/date_time_options.rs
+++ b/src/schema/date_time_options.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::schema::flags::{FastFlag, IndexedFlag, SchemaFlagList, StoredFlag};
 
 /// The precision of the indexed date/time values in the inverted index.
-pub const DATE_TIME_PRECISION_INDEXED: DateTimePrecision = DateTimePrecision::Seconds;
+pub const DATE_TIME_PRECISION_INDEXED: DateTimePrecision = DateTimePrecision::Nanoseconds;
 
 /// Defines how DateTime field should be handled by tantivy.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]


### PR DESCRIPTION
Use nanosecond precision when indexing datetimes.