### PR TITLE
Propagate span context through more parts of tantivy

### DIFF
--- a/src/core/executor.rs
+++ b/src/core/executor.rs
@@ -52,13 +52,17 @@ impl Executor {
                 let num_fruits = args.len();
                 let fruit_receiver = {
                     let (fruit_sender, fruit_receiver) = crossbeam_channel::unbounded();
+                    let parent_span = tracing::Span::current();
                     pool.scope(|scope| {
+                        let _parent_span_guard = parent_span.enter();
                         for (idx, arg) in args.into_iter().enumerate() {
                             // We name references for f and fruit_sender_ref because we do not
                             // want these two to be moved into the closure.
                             let f_ref = &f;
                             let fruit_sender_ref = &fruit_sender;
+                            let parent_span = tracing::Span::current();
                             scope.spawn(move |_| {
+                                let _parent_span_guard = parent_span.enter();
                                 let fruit = f_ref(arg);
                                 if let Err(err) = fruit_sender_ref.send((idx, fruit)) {
                                     error!(
@@ -111,7 +115,9 @@ impl Executor {
                 })?;
             }
             Executor::ThreadPool(pool) => {
+                let parent_span = tracing::Span::current();
                 pool.spawn(move || {
+                    let _parent_span_guard = parent_span.enter();
                     let res = op();
                     match fruit_sender.send(res) {
                         Ok(_) => (),

--- a/src/directory/file_watcher.rs
+++ b/src/directory/file_watcher.rs
@@ -39,10 +39,12 @@ impl FileWatcher {
         let path = self.path.clone();
         let callbacks = self.callbacks.clone();
         let state = self.state.clone();
+        let parent_span = tracing::Span::current();
 
         thread::Builder::new()
             .name("thread-tantivy-meta-file-watcher".to_string())
             .spawn(move || {
+                let _parent_span_guard = parent_span.enter();
                 let mut current_checksum_opt = None;
 
                 while state.load(Ordering::SeqCst) == 1 {

--- a/src/directory/watch_event_router.rs
+++ b/src/directory/watch_event_router.rs
@@ -81,9 +81,11 @@ impl WatchCallbackList {
             let _ = sender.send(Ok(()));
             return result;
         }
+        let parent_span = tracing::Span::current();
         let spawn_res = std::thread::Builder::new()
             .name("watch-callbacks".to_string())
             .spawn(move || {
+                let _parent_span_guard = parent_span.enter();
                 for callback in callbacks {
                     callback.call();
                 }

--- a/src/reader/warming.rs
+++ b/src/reader/warming.rs
@@ -134,9 +134,13 @@ impl WarmingStateInner {
             return Ok(false);
         }
         let weak_inner = Arc::downgrade(this);
+        let parent_span = tracing::Span::current();
         let handle = std::thread::Builder::new()
             .name("tantivy-warm-gc".to_owned())
-            .spawn(|| Self::gc_loop(weak_inner))
+            .spawn(move || {
+                let _parent_span_guard = parent_span.enter();
+                Self::gc_loop(weak_inner)
+            })
             .map_err(|_| {
                 TantivyError::SystemError("Failed to spawn warmer GC thread".to_owned())
             })?;

--- a/src/store/store_compressor.rs
+++ b/src/store/store_compressor.rs
@@ -171,9 +171,11 @@ impl DedicatedThreadBlockCompressorImpl {
             SyncSender<BlockCompressorMessage>,
             Receiver<BlockCompressorMessage>,
         ) = sync_channel(3);
+        let parent_span = tracing::Span::current();
         let join_handle = thread::Builder::new()
             .name("docstore-compressor-thread".to_string())
             .spawn(move || {
+                let _parent_span_guard = parent_span.enter();
                 while let Ok(packet) = rx.recv() {
                     match packet {
                         BlockCompressorMessage::CompressBlockAndWrite {


### PR DESCRIPTION
In order to make sure span lineage makes it through tantivy, we have to explicitly propagate the span through any thread boundaries.