### PR TITLE
Fix fieldnorm merge

### DIFF
--- a/src/index/segment_reader.rs
+++ b/src/index/segment_reader.rs
@@ -126,6 +126,23 @@ impl SegmentReader {
         })
     }
 
+    /// Returns a fieldnorm reader for the given field.
+    ///
+    /// Unlike [`get_fieldnorms_reader`](Self::get_fieldnorms_reader), this method returns a
+    /// constant fieldnorm reader (with fieldnorm 0) if the field doesn't have fieldnorms in this
+    /// segment. This is useful for merging segments where a field was added after some segments
+    /// were already created.
+    pub fn get_fieldnorms_reader_or_default(&self, field: Field) -> crate::Result<FieldNormReader> {
+        match self.fieldnorm_readers.get_field(field)? {
+            Some(reader) => Ok(reader),
+            None => {
+                // Return a constant fieldnorm reader with fieldnorm 0 for all documents.
+                // This represents "no tokens indexed in this field for any document".
+                Ok(FieldNormReader::constant(self.max_doc, 0))
+            }
+        }
+    }
+
     #[doc(hidden)]
     pub fn fieldnorms_readers(&self) -> &FieldNormReaders {
         &self.fieldnorm_readers

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -239,10 +239,13 @@ impl IndexMerger {
         let mut fieldnorms_data = Vec::with_capacity(self.max_doc as usize);
         for field in fields {
             fieldnorms_data.clear();
+            // Use get_fieldnorms_reader_or_default to handle segments created before a field
+            // was added to the schema. Those segments will return a constant fieldnorm of 0
+            // (meaning "no tokens indexed") for documents that don't have the field.
             let fieldnorms_readers: Vec<FieldNormReader> = self
                 .readers
                 .iter()
-                .map(|reader| reader.get_fieldnorms_reader(field))
+                .map(|reader| reader.get_fieldnorms_reader_or_default(field))
                 .collect::<Result<_, _>>()?;
             for old_doc_addr in doc_id_mapping.iter_old_doc_addrs() {
                 let fieldnorms_reader = &fieldnorms_readers[old_doc_addr.segment_ord as usize];


### PR DESCRIPTION
When merging two segments, if one of them does not have a fieldnorm file, default it to empty