### PR TITLE
Limit allocations in top_docs

### DIFF
--- a/src/aggregation/agg_req_with_accessor.rs
+++ b/src/aggregation/agg_req_with_accessor.rs
@@ -36,6 +36,7 @@ impl AggregationsWithAccessor {
 
 pub struct AggregationWithAccessor {
     pub(crate) segment_ordinal: SegmentOrdinal,
+    pub(crate) segment_size: usize,
     /// In general there can be buckets without fast field access, e.g. buckets that are created
     /// based on search terms. That is not that case currently, but eventually this needs to be
     /// Option or moved.
@@ -72,6 +73,7 @@ impl AggregationWithAccessor {
     ) -> crate::Result<Vec<AggregationWithAccessor>> {
         let mut agg = agg.clone();
 
+        let segment_size = reader.num_docs() as usize;
         let add_agg_with_accessor = |agg: &Aggregation,
                                      accessor: Column<u64>,
                                      column_type: ColumnType,
@@ -79,6 +81,7 @@ impl AggregationWithAccessor {
          -> crate::Result<()> {
             let res = AggregationWithAccessor {
                 segment_ordinal,
+                segment_size,
                 accessor,
                 accessors: Default::default(),
                 value_accessors: Default::default(),
@@ -107,6 +110,7 @@ impl AggregationWithAccessor {
             let (accessor, field_type) = accessors.first().expect("at least one accessor");
             let res = AggregationWithAccessor {
                 segment_ordinal,
+                segment_size,
                 // TODO: We should do away with the `accessor` field altogether
                 accessor: accessor.clone(),
                 value_accessors,
@@ -236,6 +240,7 @@ impl AggregationWithAccessor {
 
                     let agg = AggregationWithAccessor {
                         segment_ordinal,
+                        segment_size,
                         missing_value_for_accessor,
                         accessor,
                         accessors: Default::default(),

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -506,10 +506,13 @@ impl TopHitsSegmentCollector {
         req: &TopHitsAggregation,
         accessor_idx: usize,
         segment_ordinal: SegmentOrdinal,
+        segment_size: usize,
     ) -> Self {
+        let requested_size = req.size + req.from.unwrap_or(0);
+        let capped_size = requested_size.min(segment_size);
         Self {
             req: req.clone(),
-            top_n: TopNComputer::new(req.size + req.from.unwrap_or(0)),
+            top_n: TopNComputer::new(capped_size),
             segment_ordinal,
             accessor_idx,
         }
@@ -535,6 +538,13 @@ impl TopHitsSegmentCollector {
         }
 
         top_hits_computer
+    }
+
+    #[cfg(test)]
+    /// Returns the capacity of the internal TopNComputer buffer.
+    /// This is a test-only function to verify buffer allocation is capped correctly.
+    pub fn buffer_capacity(&self) -> usize {
+        self.top_n.buffer_capacity()
     }
 }
 
@@ -893,5 +903,63 @@ mod tests {
     #[test]
     fn test_aggregation_top_hits_multi_segment() -> crate::Result<()> {
         test_aggregation_top_hits(false)
+    }
+
+    #[test]
+    fn test_top_hits_segment_collector_capped_by_segment_size() -> crate::Result<()> {
+        use crate::schema::{Schema, TEXT};
+        use crate::Index;
+
+        // Create a small index with only 2 documents
+        let mut schema_builder = Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        let mut index_writer = index.writer_with_num_threads(1, 20_000_000)?;
+        index_writer.add_document(doc!(text_field=>"Hello world"))?;
+        index_writer.add_document(doc!(text_field=>"Another document"))?;
+        index_writer.commit()?;
+
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        let segment_reader = searcher.segment_reader(0);
+        let segment_size = segment_reader.num_docs() as usize;
+        
+        // Verify segment has 2 documents
+        assert_eq!(segment_size, 2);
+
+        // Create a TopHitsAggregation requesting more than segment size
+        use super::KeyOrder;
+        use crate::aggregation::bucket::Order;
+        let top_hits_req = super::TopHitsAggregation {
+            size: 100,
+            from: None,
+            sort: vec![KeyOrder {
+                field: "_score".to_string(),
+                order: Order::Desc,
+            }],
+            doc_value_fields: vec![],
+            _source: None,
+            fields: None,
+            script_fields: None,
+            highlight: None,
+            explain: None,
+            version: None,
+        };
+
+        // Create TopHitsSegmentCollector - it should be capped to segment_size (2)
+        let segment_collector = super::TopHitsSegmentCollector::from_req(
+            &top_hits_req,
+            0,
+            0,
+            segment_size,
+        );
+
+        // The internal TopNComputer should have been created with capped size (2)
+        // Buffer capacity should be 2 * capped_size = 2 * 2 = 4
+        // If it wasn't capped, it would be 2 * 100 = 200
+        let buffer_capacity = segment_collector.buffer_capacity();
+        assert_eq!(buffer_capacity, 4, "Buffer should be capped to 2 * segment_size (4), but got {}", buffer_capacity);
+        Ok(())
     }
 }

--- a/src/aggregation/segment_agg_result.rs
+++ b/src/aggregation/segment_agg_result.rs
@@ -165,6 +165,7 @@ pub(crate) fn build_single_agg_segment_collector(
             top_hits_req,
             accessor_idx,
             req.segment_ordinal,
+            req.segment_size,
         ))),
     }
 }

--- a/src/collector/top_collector.rs
+++ b/src/collector/top_collector.rs
@@ -128,9 +128,12 @@ where T: PartialOrd + Clone
     pub(crate) fn for_segment<F: PartialOrd + Clone>(
         &self,
         segment_id: SegmentOrdinal,
-        _: &SegmentReader,
+        reader: &SegmentReader,
     ) -> TopSegmentCollector<F> {
-        TopSegmentCollector::new(segment_id, self.limit + self.offset)
+        let requested_limit = self.limit + self.offset;
+        let segment_size = reader.num_docs() as usize;
+        let capped_limit = requested_limit.min(segment_size);
+        TopSegmentCollector::new(segment_id, capped_limit)
     }
 
     /// Create a new TopCollector with the same limit and offset.
@@ -194,6 +197,13 @@ impl<T: PartialOrd + Clone> TopSegmentCollector<T> {
     #[inline]
     pub fn collect(&mut self, doc: DocId, feature: T) {
         self.topn_computer.push(feature, doc);
+    }
+
+    #[cfg(test)]
+    /// Returns the capacity of the internal TopNComputer buffer.
+    /// This is a test-only function to verify buffer allocation is capped correctly.
+    pub fn buffer_capacity(&self) -> usize {
+        self.topn_computer.buffer_capacity()
     }
 }
 
@@ -307,6 +317,43 @@ mod tests {
             .unwrap();
 
         assert_eq!(results, vec![]);
+    }
+
+    #[test]
+    fn test_top_collector_capped_by_segment_size() -> crate::Result<()> {
+        use crate::schema::{Schema, TEXT};
+        use crate::Index;
+
+        // Create a small index with only 2 documents
+        let mut schema_builder = Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        let mut index_writer = index.writer_with_num_threads(1, 20_000_000)?;
+        index_writer.add_document(doc!(text_field=>"Hello world"))?;
+        index_writer.add_document(doc!(text_field=>"Another document"))?;
+        index_writer.commit()?;
+
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        let segment_reader = searcher.segment_reader(0);
+        let segment_size = segment_reader.num_docs() as usize;
+        
+        // Verify segment has 2 documents
+        assert_eq!(segment_size, 2);
+
+        // Create a TopCollector requesting more than segment size
+        let collector: TopCollector<crate::Score> = TopCollector::with_limit(100);
+        
+        // Get the segment collector - it should be capped to segment_size
+        let segment_collector: TopSegmentCollector<crate::Score> = collector.for_segment(0, segment_reader);
+        
+        // The internal TopNComputer should have been created with capped size (2)
+        // Buffer capacity should be 2 * capped_limit = 2 * 2 = 4
+        // If it wasn't capped, it would be 2 * 100 = 200
+        let buffer_capacity = segment_collector.buffer_capacity();
+        assert_eq!(buffer_capacity, 4, "Buffer should be capped to 2 * segment_size (4), but got {}", buffer_capacity);
+        Ok(())
     }
 }
 

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -665,7 +665,9 @@ impl Collector for TopDocs {
         reader: &SegmentReader,
     ) -> crate::Result<<Self::Child as SegmentCollector>::Fruit> {
         let heap_len = self.0.limit + self.0.offset;
-        let mut top_n: TopNComputer<_, _> = TopNComputer::new(heap_len);
+        let segment_size = reader.num_docs() as usize;
+        let capped_heap_len = heap_len.min(segment_size);
+        let mut top_n: TopNComputer<_, _> = TopNComputer::new(capped_heap_len);
 
         if let Some(alive_bitset) = reader.alive_bitset() {
             let mut threshold = Score::MIN;
@@ -714,6 +716,15 @@ impl SegmentCollector for TopScoreSegmentCollector {
 
     fn harvest(self) -> Vec<(Score, DocAddress)> {
         self.0.harvest()
+    }
+}
+
+#[cfg(test)]
+impl TopScoreSegmentCollector {
+    /// Returns the capacity of the internal TopNComputer buffer.
+    /// This is a test-only function to verify buffer allocation is capped correctly.
+    pub fn buffer_capacity(&self) -> usize {
+        self.0.buffer_capacity()
     }
 }
 
@@ -859,6 +870,13 @@ where
             self.truncate_top_n();
         }
         self.buffer
+    }
+
+    #[cfg(test)]
+    /// Returns the capacity of the internal buffer.
+    /// This is a test-only function to verify buffer allocation is capped correctly.
+    pub fn buffer_capacity(&self) -> usize {
+        self.buffer.capacity()
     }
 }
 
@@ -1369,6 +1387,86 @@ mod tests {
                 (18446744073709551615, DocAddress::new(0, 3)),
             ]
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_top_docs_capped_by_segment_size() -> crate::Result<()> {
+        // Create a small index with only 2 documents
+        let mut schema_builder = Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        let mut index_writer = index.writer_with_num_threads(1, 20_000_000)?;
+        index_writer.add_document(doc!(text_field=>"Hello world"))?;
+        index_writer.add_document(doc!(text_field=>"Another document"))?;
+        index_writer.commit()?;
+
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        let segment_reader = searcher.segment_reader(0);
+        let segment_size = segment_reader.num_docs() as usize;
+        
+        // Verify segment has 2 documents
+        assert_eq!(segment_size, 2);
+
+        // Create collector and get segment collector to check buffer capacity
+        let collector = TopDocs::with_limit(100);
+        let segment_collector = collector.for_segment(0, segment_reader)?;
+        
+        // Buffer capacity should be 2 * capped_limit = 2 * 2 = 4
+        // If it wasn't capped, it would be 2 * 100 = 200
+        let buffer_capacity = segment_collector.buffer_capacity();
+        assert_eq!(buffer_capacity, 4, "Buffer should be capped to 2 * segment_size (4), but got {}", buffer_capacity);
+
+        // Also verify it works correctly when searching
+        // Use AllQuery to match all documents in the segment
+        let top_docs: Vec<(Score, DocAddress)> = searcher
+            .search(&AllQuery, &TopDocs::with_limit(100))?;
+
+        // Should only return 2 documents (capped by segment size)
+        assert_eq!(top_docs.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_top_docs_with_offset_capped_by_segment_size() -> crate::Result<()> {
+        // Create a small index with only 3 documents
+        let mut schema_builder = Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        let mut index_writer = index.writer_with_num_threads(1, 20_000_000)?;
+        index_writer.add_document(doc!(text_field=>"First document"))?;
+        index_writer.add_document(doc!(text_field=>"Second document"))?;
+        index_writer.add_document(doc!(text_field=>"Third document"))?;
+        index_writer.commit()?;
+
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        let segment_reader = searcher.segment_reader(0);
+        let segment_size = segment_reader.num_docs() as usize;
+        
+        // Verify segment has 3 documents
+        assert_eq!(segment_size, 3);
+
+        // Create collector with offset and get segment collector to check buffer capacity
+        let collector = TopDocs::with_limit(100).and_offset(1);
+        let segment_collector = collector.for_segment(0, segment_reader)?;
+        
+        // Requested limit is 100 + 1 = 101, but should be capped to segment_size (3)
+        // Buffer capacity should be 2 * capped_limit = 2 * 3 = 6
+        // If it wasn't capped, it would be 2 * 101 = 202
+        let buffer_capacity = segment_collector.buffer_capacity();
+        assert_eq!(buffer_capacity, 6, "Buffer should be capped to 2 * segment_size (6), but got {}", buffer_capacity);
+
+        // Also verify it works correctly when searching
+        // Use AllQuery to match all documents in the segment
+        let top_docs: Vec<(Score, DocAddress)> = searcher
+            .search(&AllQuery, &TopDocs::with_limit(100).and_offset(1))?;
+
+        // Should only return 2 documents (3 total - 1 offset, capped by segment size)
+        assert_eq!(top_docs.len(), 2);
         Ok(())
     }
 }


### PR DESCRIPTION
We don't need to allocate a buffer larger than the number of docs in the segment