### PR TITLE
Stricter error handling for vector reader

### DIFF
--- a/src/index/segment_reader.rs
+++ b/src/index/segment_reader.rs
@@ -6,6 +6,7 @@ use std::{fmt, io};
 use fnv::FnvHashMap;
 use itertools::Itertools;
 
+use crate::directory::error::OpenReadError;
 use crate::directory::{CompositeFile, FileSlice};
 use crate::error::DataCorruption;
 use crate::fastfield::{intersect_alive_bitsets, AliveBitSet, FacetReader, FastFieldReaders};
@@ -203,7 +204,11 @@ impl SegmentReader {
         };
 
         // Try to load vector file if it exists
-        let vector_file_opt = segment.open_read(SegmentComponent::Vectors).ok();
+        let vector_file_opt = match segment.open_read(SegmentComponent::Vectors) {
+            Ok(vector_file) => Some(vector_file),
+            Err(OpenReadError::FileDoesNotExist(_)) => None,
+            Err(e) => return Err(e.into()),
+        };
 
         let alive_bitset_opt = intersect_alive_bitset(original_bitset, custom_bitset);
 
@@ -436,13 +441,13 @@ impl SegmentReader {
     /// Returns `None` if the segment has no vector data.
     /// The `field` parameter is used for API consistency but all fields' vectors
     /// are stored in the same file.
-    pub fn vector_reader(&self, _field: Field) -> Option<VectorReader> {
-        self.vector_file_opt.as_ref().and_then(|file_slice| {
-            file_slice
-                .read_bytes()
-                .ok()
-                .and_then(|bytes| VectorReader::open(bytes.as_slice()).ok())
-        })
+    pub fn vector_reader(&self, _field: Field) -> io::Result<Option<VectorReader>> {
+        match self.vector_file_opt.as_ref() {
+            None => Ok(None),
+            Some(file_slice) => {
+                Ok(Some(VectorReader::open(file_slice.read_bytes()?)?))
+            }
+        }
     }
 
     /// Returns the bitset representing the alive `DocId`s.

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -232,7 +232,7 @@ mod tests {
         let mut summary_count = 0;
 
         for segment_reader in searcher.segment_readers() {
-            if let Some(vector_reader) = segment_reader.vector_reader(embedding_field) {
+            if let Some(vector_reader) = segment_reader.vector_reader(embedding_field).unwrap() {
                 // Count vectors using columnar iteration
                 for (_doc_id, _vec) in vector_reader.iter_vectors(embedding_field, "chunk_0") {
                     chunk0_count += 1;
@@ -273,7 +273,7 @@ mod tests {
         );
 
         let segment_reader = searcher.segment_reader(0);
-        let vector_reader = segment_reader.vector_reader(embedding_field);
+        let vector_reader = segment_reader.vector_reader(embedding_field).unwrap();
         assert!(vector_reader.is_some(), "Expected vector reader after merge");
         let vector_reader = vector_reader.unwrap();
 
@@ -355,7 +355,7 @@ mod tests {
         let mut doc_ids: Vec<u32> = Vec::new();
 
         for segment_reader in searcher.segment_readers() {
-            if let Some(vector_reader) = segment_reader.vector_reader(embedding_field) {
+            if let Some(vector_reader) = segment_reader.vector_reader(embedding_field).unwrap() {
                 for (doc_id, vec) in vector_reader.iter_vectors(embedding_field, "embedding") {
                     doc_ids.push(doc_id);
                     all_vectors.push(vec.into_owned());


### PR DESCRIPTION
The original implementation for opening a vector reader would swallow all IOErrors into None, meaning we might ignore vector data that exists due to arbitrary IO errors.

It seems like the original intent was to gracefully skip over vector data when the tantivy index doesn't contain any vector files, even if the schema does. But this should be handled by optionally initializing the the vector reader file handle. Reading the subsequent data should not have to handle the file missing.

We can test this by creating a tantivy index with no vector data, updating the schema to include vector fields, and then verifying that the vector reader gracefully skips over the missing file.