### PR TITLE
Use sparse vecs for fast fields during merges

### DIFF
--- a/columnar/src/columnar/merge/mod.rs
+++ b/columnar/src/columnar/merge/mod.rs
@@ -263,33 +263,30 @@ impl GroupedColumns {
 
 struct GroupedColumnsHandle {
     required_column_type: Option<ColumnType>,
-    columns: Vec<Option<DynamicColumnHandle>>,
+    num_columnars: usize,
+    columns: Vec<(u32, DynamicColumnHandle)>,
 }
 
 impl GroupedColumnsHandle {
     fn new(num_columnars: usize) -> Self {
         GroupedColumnsHandle {
             required_column_type: None,
-            columns: vec![None; num_columnars],
+            num_columnars,
+            columns: Vec::new(),
         }
     }
     fn open(self, merge_row_order: &MergeRowOrder) -> io::Result<GroupedColumns> {
-        let mut columns: Vec<Option<DynamicColumn>> = Vec::new();
-        for (columnar_id, column) in self.columns.iter().enumerate() {
-            if let Some(column) = column {
-                let column = column.open()?;
-                // We skip columns that end up with 0 documents.
-                // That way, we make sure they don't end up influencing the merge type or
-                // creating empty columns.
-
-                if is_empty_after_merge(merge_row_order, &column, columnar_id) {
-                    columns.push(None);
-                } else {
-                    columns.push(Some(column));
-                }
-            } else {
-                columns.push(None);
+        let mut columns: Vec<Option<DynamicColumn>> = vec![None; self.num_columnars];
+        for (columnar_id, column) in self.columns {
+            let column = column.open()?;
+            let columnar_id = columnar_id as usize;
+            // We skip columns that end up with 0 documents.
+            // That way, we make sure they don't end up influencing the merge type or
+            // creating empty columns.
+            if is_empty_after_merge(merge_row_order, &column, columnar_id) {
+                continue;
             }
+            columns[columnar_id] = Some(column);
         }
         Ok(GroupedColumns {
             required_column_type: self.required_column_type,
@@ -299,7 +296,9 @@ impl GroupedColumnsHandle {
 
     /// Set the dynamic column for a given columnar.
     fn set_column(&mut self, columnar_id: usize, column: DynamicColumnHandle) {
-        self.columns[columnar_id] = Some(column);
+        let columnar_id = u32::try_from(columnar_id)
+            .expect("columnar_id exceeds u32::MAX while grouping columns for merge");
+        self.columns.push((columnar_id, column));
     }
 
     /// Force the existence of a column, as well as its type.

--- a/columnar/src/columnar/merge/tests.rs
+++ b/columnar/src/columnar/merge/tests.rs
@@ -90,9 +90,7 @@ fn test_group_columns_required_column_with_no_existing_columns() {
         .get(&("required_col".to_string(), ColumnTypeCategory::Str))
         .unwrap()
         .columns;
-    assert_eq!(columns.len(), 2);
-    assert!(columns[0].is_none());
-    assert!(columns[1].is_none());
+    assert!(columns.is_empty());
 }
 
 #[test]
@@ -123,20 +121,20 @@ fn test_missing_column() {
     assert_eq!(column_map.len(), 2);
     assert!(column_map.contains_key(&("numbers".to_string(), ColumnTypeCategory::Numerical)));
     {
-        let columns = &column_map
+        let grouped_columns = column_map
             .get(&("numbers".to_string(), ColumnTypeCategory::Numerical))
-            .unwrap()
-            .columns;
-        assert!(columns[0].is_some());
-        assert!(columns[1].is_none());
+            .unwrap();
+        assert_eq!(grouped_columns.num_columnars, 2);
+        assert_eq!(grouped_columns.columns.len(), 1);
+        assert_eq!(grouped_columns.columns[0].0, 0);
     }
     {
-        let columns = &column_map
+        let grouped_columns = column_map
             .get(&("numbers2".to_string(), ColumnTypeCategory::Numerical))
-            .unwrap()
-            .columns;
-        assert!(columns[0].is_none());
-        assert!(columns[1].is_some());
+            .unwrap();
+        assert_eq!(grouped_columns.num_columnars, 2);
+        assert_eq!(grouped_columns.columns.len(), 1);
+        assert_eq!(grouped_columns.columns[0].0, 1);
     }
 }
 


### PR DESCRIPTION
During merges, for each fast field we were allocating a vec of size num_chunks. This is O(num_chunks * num_fast_fields) memory. There was a segment with 4577 chunks and 4mil fast fields, which blows up to around 742GB. If most of these columns are sparse, then most of this memory is wasted. We can instead only store the column handles for segments that contain the column so that we dont spend so much memory storing None. 