### PR TITLE
Reuse the merge thread pool for merge ops

### DIFF
--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -7,9 +7,10 @@ use columnar::{
 use common::{CountingWriter, ReadOnlyBitSet, TerminatingWrite};
 use itertools::Itertools;
 use measure_time::debug_time;
+use rayon::prelude::*;
+use rayon::ThreadPool;
 
 use super::segment_serializer::SegmentSerializerParts;
-use crate::core::Executor;
 use crate::directory::WritePtr;
 use crate::docset::{DocSet, TERMINATED};
 use crate::error::DataCorruption;
@@ -890,12 +891,54 @@ impl IndexMerger {
         Ok(())
     }
 
+    fn run_merge_write_task(
+        &self,
+        task: MergeWriteTask,
+        doc_id_mapping: &SegmentDocIdMapping,
+        merged_doc_id_map: &[Vec<Option<DocId>>],
+    ) -> crate::Result<MergeWriteTaskOutput> {
+        match task {
+            MergeWriteTask::Postings(field_job) => self
+                .write_postings_for_field(
+                    field_job.field,
+                    &field_job.field_name,
+                    field_job.fieldnorm_reader,
+                    doc_id_mapping,
+                    merged_doc_id_map,
+                )
+                .map(MergeWriteTaskOutput::Postings),
+            MergeWriteTask::StorableFields {
+                mut store_writer,
+                doc_id_mapping,
+            } => {
+                debug!("write-storagefields");
+                self.write_storable_fields(&mut store_writer, &doc_id_mapping)?;
+                tracing::info_span!("close_store_writer").in_scope(|| store_writer.close())?;
+                Ok(MergeWriteTaskOutput::StorableFields)
+            }
+            MergeWriteTask::FastFields {
+                mut fast_field_write,
+                doc_id_mapping,
+            } => {
+                debug!("write-fastfields");
+                self.write_fast_fields(&mut fast_field_write, doc_id_mapping)?;
+                tracing::info_span!("close_fast_fields_writer")
+                    .in_scope(|| fast_field_write.terminate())?;
+                Ok(MergeWriteTaskOutput::FastFields)
+            }
+        }
+    }
+
     /// Writes the merged segment by pushing information
     /// to the `SegmentSerializer`.
     ///
     /// # Returns
     /// The number of documents in the resulting segment.
-    pub fn write(&self, mut serializer: SegmentSerializer) -> crate::Result<u32> {
+    pub fn write(
+        &self,
+        mut serializer: SegmentSerializer,
+        merge_thread_pool: Option<&ThreadPool>,
+    ) -> crate::Result<u32> {
         let input_space_usage = MergeInputSpaceUsage::from_readers(&self.readers)?;
         let has_vector_fields = self.has_vector_fields();
         let doc_id_mapping = if let Some(sort_by_field) = self.index_settings.sort_by_field.as_ref()
@@ -973,44 +1016,26 @@ impl IndexMerger {
             fast_field_write,
             doc_id_mapping: doc_id_mapping.clone(),
         });
-        let merge_write_executor = if self.postings_parallelism() <= 1 {
-            Executor::single_thread()
+        let write_results = if self.postings_parallelism() <= 1 || write_tasks.len() <= 1 {
+            write_tasks
+                .into_iter()
+                .map(|task| self.run_merge_write_task(task, &doc_id_mapping, &merged_doc_id_map))
+                .collect::<crate::Result<Vec<_>>>()?
+        } else if let Some(merge_thread_pool) = merge_thread_pool {
+            merge_thread_pool.install(|| {
+                write_tasks
+                    .into_par_iter()
+                    .map(|task| {
+                        self.run_merge_write_task(task, &doc_id_mapping, &merged_doc_id_map)
+                    })
+                    .collect::<crate::Result<Vec<_>>>()
+            })?
         } else {
-            Executor::multi_thread(self.postings_parallelism(), "merge_write_")?
+            write_tasks
+                .into_iter()
+                .map(|task| self.run_merge_write_task(task, &doc_id_mapping, &merged_doc_id_map))
+                .collect::<crate::Result<Vec<_>>>()?
         };
-        let write_results = merge_write_executor.map(
-            |task| match task {
-                MergeWriteTask::Postings(field_job) => self
-                    .write_postings_for_field(
-                        field_job.field,
-                        &field_job.field_name,
-                        field_job.fieldnorm_reader,
-                        &doc_id_mapping,
-                        &merged_doc_id_map,
-                    )
-                    .map(MergeWriteTaskOutput::Postings),
-                MergeWriteTask::StorableFields {
-                    mut store_writer,
-                    doc_id_mapping,
-                } => {
-                    debug!("write-storagefields");
-                    self.write_storable_fields(&mut store_writer, &doc_id_mapping)?;
-                    tracing::info_span!("close_store_writer").in_scope(|| store_writer.close())?;
-                    Ok(MergeWriteTaskOutput::StorableFields)
-                }
-                MergeWriteTask::FastFields {
-                    mut fast_field_write,
-                    doc_id_mapping,
-                } => {
-                    debug!("write-fastfields");
-                    self.write_fast_fields(&mut fast_field_write, doc_id_mapping)?;
-                    tracing::info_span!("close_fast_fields_writer")
-                        .in_scope(|| fast_field_write.terminate())?;
-                    Ok(MergeWriteTaskOutput::FastFields)
-                }
-            },
-            write_tasks.into_iter(),
-        )?;
         let total_serialized_postings_output_bytes = write_results
             .iter()
             .filter_map(|result| match result {

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -87,6 +87,7 @@ fn garbage_collect_files(
 /// This function happens in the calling thread and is computationally expensive.
 fn merge(
     index: &Index,
+    merge_thread_pool: &ThreadPool,
     mut segment_entries: Vec<SegmentEntry>,
     target_opstamp: Opstamp,
 ) -> crate::Result<Option<SegmentEntry>> {
@@ -144,7 +145,7 @@ fn merge(
         .in_scope(|| SegmentSerializer::for_segment(merged_segment.clone(), true))?;
 
     let num_docs = tracing::info_span!("write_merged_segment")
-        .in_scope(|| merger.write(segment_serializer))?;
+        .in_scope(|| merger.write(segment_serializer, Some(merge_thread_pool)))?;
 
     let merged_segment_id = merged_segment.id();
 
@@ -250,7 +251,7 @@ pub fn merge_filtered_segments<T: Into<Box<dyn Directory>>>(
         filter_doc_ids,
     )?;
     let segment_serializer = SegmentSerializer::for_segment(merged_segment, true)?;
-    let num_docs = merger.write(segment_serializer)?;
+    let num_docs = merger.write(segment_serializer, None)?;
 
     let segment_meta = merged_index.new_segment_meta(merged_segment_id, num_docs);
 
@@ -548,6 +549,7 @@ impl SegmentUpdater {
             // candidate for another merge.
             match merge(
                 &segment_updater.index,
+                &segment_updater.merge_thread_pool,
                 segment_entries,
                 merge_operation.target_opstamp(),
             ) {
@@ -701,6 +703,12 @@ impl SegmentUpdater {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use rayon::prelude::*;
+    use rayon::ThreadPoolBuilder;
+
     use super::merge_indices;
     use crate::collector::TopDocs;
     use crate::directory::RamDirectory;
@@ -711,6 +719,39 @@ mod tests {
     use crate::query::QueryParser;
     use crate::schema::*;
     use crate::{Directory, DocAddress, Index, Segment};
+
+    #[test]
+    fn test_nested_merge_thread_pool_parallelism_does_not_deadlock() {
+        let pool = Arc::new(
+            ThreadPoolBuilder::new()
+                .num_threads(4)
+                .thread_name(|i| format!("merge-thread-test-{i}"))
+                .build()
+                .unwrap(),
+        );
+        let (tx, rx) = std::sync::mpsc::channel();
+        for outer_job in 0..8usize {
+            let pool_for_spawn = pool.clone();
+            let pool_for_install = pool.clone();
+            let tx = tx.clone();
+            pool_for_spawn.spawn(move || {
+                let result = pool_for_install.install(|| {
+                    (0..8usize)
+                        .into_par_iter()
+                        .map(|inner_job| {
+                            std::thread::sleep(Duration::from_millis(1));
+                            outer_job * 100 + inner_job
+                        })
+                        .sum::<usize>()
+                });
+                tx.send(result).unwrap();
+            });
+        }
+        drop(tx);
+
+        let results: Vec<_> = rx.iter().collect();
+        assert_eq!(results.len(), 8);
+    }
 
     #[test]
     fn test_delete_during_merge() -> crate::Result<()> {


### PR DESCRIPTION
Without this, we'd spin up a 4-thread pool for each op