### PR TITLE
Cheaper vector presence filter

### DIFF
--- a/src/index/segment_reader.rs
+++ b/src/index/segment_reader.rs
@@ -17,7 +17,10 @@ use crate::schema::{Field, IndexRecordOption, Schema, Type};
 use crate::space_usage::SegmentSpaceUsage;
 use crate::store::StoreReader;
 use crate::termdict::TermDictionary;
-use crate::vector::{read_vector_presence, PresenceBitset, VectorReader};
+use crate::vector::{
+    open_vector_column_reader, read_vector_presence, PresenceBitset, VectorColumnReader,
+    VectorReader,
+};
 use crate::{DocId, Executor, Opstamp};
 
 /// Entry point to access all of the datastructures of the `Segment`
@@ -459,6 +462,18 @@ impl SegmentReader {
         match self.vector_file_opt.as_ref() {
             None => Ok(None),
             Some(file_slice) => read_vector_presence(file_slice, field, vector_id),
+        }
+    }
+
+    /// Returns a lazy reader for a specific vector column in this segment.
+    pub fn vector_column_reader(
+        &self,
+        field: Field,
+        vector_id: &str,
+    ) -> io::Result<Option<VectorColumnReader>> {
+        match self.vector_file_opt.as_ref() {
+            None => Ok(None),
+            Some(file_slice) => open_vector_column_reader(file_slice, field, vector_id),
         }
     }
 

--- a/src/index/segment_reader.rs
+++ b/src/index/segment_reader.rs
@@ -17,7 +17,7 @@ use crate::schema::{Field, IndexRecordOption, Schema, Type};
 use crate::space_usage::SegmentSpaceUsage;
 use crate::store::StoreReader;
 use crate::termdict::TermDictionary;
-use crate::vector::VectorReader;
+use crate::vector::{read_vector_presence, PresenceBitset, VectorReader};
 use crate::{DocId, Executor, Opstamp};
 
 /// Entry point to access all of the datastructures of the `Segment`
@@ -447,6 +447,18 @@ impl SegmentReader {
             Some(file_slice) => {
                 Ok(Some(VectorReader::open(file_slice.read_bytes()?)?))
             }
+        }
+    }
+
+    /// Returns the presence bitset for a specific vector ID in this segment.
+    pub fn vector_presence(
+        &self,
+        field: Field,
+        vector_id: &str,
+    ) -> io::Result<Option<PresenceBitset>> {
+        match self.vector_file_opt.as_ref() {
+            None => Ok(None),
+            Some(file_slice) => read_vector_presence(file_slice, field, vector_id),
         }
     }
 

--- a/src/vector/format.rs
+++ b/src/vector/format.rs
@@ -129,6 +129,13 @@ pub fn decode_f16(bytes: &[u8]) -> Vec<f32> {
         .collect()
 }
 
+fn decode_f32(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
 /// Encode f32 vector to bytes based on encoding.
 pub fn encode_vector(
     vec: &[f32],
@@ -153,7 +160,10 @@ pub fn decode_vector<'a>(
     quant: Option<&Int8QuantParams>,
 ) -> Cow<'a, [f32]> {
     match encoding {
-        VectorEncoding::F32 => Cow::Borrowed(bytemuck::cast_slice(bytes)),
+        VectorEncoding::F32 => match bytemuck::try_cast_slice(bytes) {
+            Ok(floats) => Cow::Borrowed(floats),
+            Err(_) => Cow::Owned(decode_f32(bytes)),
+        },
         VectorEncoding::F16 => Cow::Owned(decode_f16(bytes)),
         VectorEncoding::Int8 => {
             let quant = quant.expect("Int8 encoding requires quantization params");
@@ -339,6 +349,15 @@ mod tests {
                 assert!((o - d).abs() < 0.01, "int8 roundtrip: {} vs {}", o, d);
             }
         }
+    }
+
+    #[test]
+    fn test_decode_vector_handles_unaligned_f32_bytes() {
+        let mut encoded = vec![0u8];
+        encoded.extend_from_slice(&encode_vector(&[1.5, -2.0, 3.25], VectorEncoding::F32, None));
+
+        let decoded = decode_vector(&encoded[1..], VectorEncoding::F32, None);
+        assert_eq!(decoded.as_ref(), &[1.5, -2.0, 3.25]);
     }
 
     #[test]

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -73,7 +73,7 @@ mod reader;
 mod writer;
 
 pub use format::{VectorEncoding, Int8QuantParams, PresenceBitset, PresenceBitsetBuilder, VECTOR_MAGIC, VECTOR_VERSION};
-pub use reader::{read_vector_presence, VectorReader};
+pub use reader::{open_vector_column_reader, read_vector_presence, VectorColumnReader, VectorReader};
 pub use writer::VectorFieldsWriter;
 
 #[cfg(test)]

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -73,7 +73,7 @@ mod reader;
 mod writer;
 
 pub use format::{VectorEncoding, Int8QuantParams, PresenceBitset, PresenceBitsetBuilder, VECTOR_MAGIC, VECTOR_VERSION};
-pub use reader::VectorReader;
+pub use reader::{read_vector_presence, VectorReader};
 pub use writer::VectorFieldsWriter;
 
 #[cfg(test)]
@@ -579,4 +579,3 @@ mod tests {
         assert_eq!(vectors.get(&1).unwrap().len(), 3, "Doc 2 should have 3 dimensions");
     }
 }
-

--- a/src/vector/reader.rs
+++ b/src/vector/reader.rs
@@ -93,6 +93,159 @@ pub struct VectorReader {
     encoding: VectorEncoding,
 }
 
+/// Reader for a single vector column backed by a lazy `FileSlice`.
+///
+/// Unlike `VectorReader`, this only tracks metadata and a payload slice for one
+/// `(field, vector_id)` pair. Vector bytes are fetched on demand for specific
+/// doc ids.
+#[derive(Clone)]
+pub struct VectorColumnReader {
+    dimensions: u32,
+    presence: PresenceBitset,
+    data: FileSlice,
+    encoding: VectorEncoding,
+    quant_params: Option<Int8QuantParams>,
+}
+
+impl VectorColumnReader {
+    /// Gets the dimensions of vectors in this column.
+    pub fn dimensions(&self) -> u32 {
+        self.dimensions
+    }
+
+    /// Gets the number of vectors in this column.
+    pub fn count(&self) -> u32 {
+        self.presence.count_ones()
+    }
+
+    /// Checks whether the given doc has a vector in this column.
+    pub fn has_vector(&self, doc_id: DocId) -> bool {
+        self.presence.get(doc_id)
+    }
+
+    /// Reads a single vector for a document.
+    pub fn get(&self, doc_id: DocId) -> io::Result<Option<Vec<f32>>> {
+        if !self.has_vector(doc_id) {
+            return Ok(None);
+        }
+
+        let bytes_per_vec = self.dimensions as usize * self.encoding.bytes_per_dim();
+        let vector_idx = self.presence.count_ones_before(doc_id) as usize;
+        let start = vector_idx * bytes_per_vec;
+        let end = start + bytes_per_vec;
+        let bytes = self.data.read_bytes_slice(start..end)?;
+        Ok(Some(
+            decode_vector(bytes.as_ref(), self.encoding, self.quant_params.as_ref()).into_owned(),
+        ))
+    }
+
+    /// Reads vectors for a set of doc ids without materializing the whole column.
+    pub fn get_batch(&self, doc_ids: &[DocId]) -> io::Result<Vec<Option<Vec<f32>>>> {
+        let mut results = vec![None; doc_ids.len()];
+        if doc_ids.is_empty() {
+            return Ok(results);
+        }
+
+        let bytes_per_vec = self.dimensions as usize * self.encoding.bytes_per_dim();
+        let mut requests: Vec<(usize, usize)> = doc_ids
+            .iter()
+            .enumerate()
+            .filter_map(|(result_idx, &doc_id)| {
+                self.has_vector(doc_id).then(|| {
+                    let vector_idx = self.presence.count_ones_before(doc_id) as usize;
+                    (result_idx, vector_idx * bytes_per_vec)
+                })
+            })
+            .collect();
+
+        if requests.is_empty() {
+            return Ok(results);
+        }
+
+        requests.sort_by_key(|(_, start)| *start);
+
+        let mut run_count = 0usize;
+        let mut covered_bytes = 0usize;
+        let mut idx = 0usize;
+        while idx < requests.len() {
+            run_count += 1;
+            let run_start = requests[idx].1;
+            let mut run_end = run_start + bytes_per_vec;
+            idx += 1;
+
+            while idx < requests.len() {
+                let next_start = requests[idx].1;
+                if next_start > run_end {
+                    break;
+                }
+                run_end = run_end.max(next_start + bytes_per_vec);
+                idx += 1;
+            }
+
+            covered_bytes += run_end - run_start;
+        }
+
+        let column_len = self.data.len();
+        let should_read_whole_column =
+            column_len <= 1 << 20 || run_count >= 4 || covered_bytes * 2 >= column_len;
+
+        if should_read_whole_column {
+            let bytes = self.data.read_bytes()?;
+            let bytes_ref = bytes.as_ref();
+
+            for &(result_idx, absolute_start) in &requests {
+                let end = absolute_start + bytes_per_vec;
+                results[result_idx] = Some(
+                    decode_vector(
+                        &bytes_ref[absolute_start..end],
+                        self.encoding,
+                        self.quant_params.as_ref(),
+                    )
+                    .into_owned(),
+                );
+            }
+
+            return Ok(results);
+        }
+
+        let mut run_start_idx = 0;
+        while run_start_idx < requests.len() {
+            let run_start = requests[run_start_idx].1;
+            let mut run_end = run_start + bytes_per_vec;
+            let mut run_end_idx = run_start_idx + 1;
+
+            while run_end_idx < requests.len() {
+                let next_start = requests[run_end_idx].1;
+                if next_start > run_end {
+                    break;
+                }
+                run_end = run_end.max(next_start + bytes_per_vec);
+                run_end_idx += 1;
+            }
+
+            let bytes = self.data.read_bytes_slice(run_start..run_end)?;
+            let bytes_ref = bytes.as_ref();
+
+            for &(result_idx, absolute_start) in &requests[run_start_idx..run_end_idx] {
+                let local_start = absolute_start - run_start;
+                let local_end = local_start + bytes_per_vec;
+                results[result_idx] = Some(
+                    decode_vector(
+                        &bytes_ref[local_start..local_end],
+                        self.encoding,
+                        self.quant_params.as_ref(),
+                    )
+                    .into_owned(),
+                );
+            }
+
+            run_start_idx = run_end_idx;
+        }
+
+        Ok(results)
+    }
+}
+
 struct FileSliceCursor<'a> {
     file_slice: &'a FileSlice,
     offset: usize,
@@ -134,6 +287,13 @@ impl<'a> FileSliceCursor<'a> {
         Ok(u32::from_le_bytes(raw))
     }
 
+    fn read_f32(&mut self) -> io::Result<f32> {
+        let bytes = self.read_slice(4)?;
+        let mut raw = [0u8; 4];
+        raw.copy_from_slice(bytes.as_ref());
+        Ok(f32::from_le_bytes(raw))
+    }
+
     fn skip(&mut self, len: usize) -> io::Result<()> {
         let end = self.offset.checked_add(len).ok_or_else(|| {
             io::Error::new(io::ErrorKind::InvalidData, "vector file offset overflow")
@@ -149,23 +309,11 @@ impl<'a> FileSliceCursor<'a> {
     }
 }
 
-fn count_ones_in_bitset_bytes(bytes: &[u8]) -> usize {
-    bytes
-        .chunks(8)
-        .map(|chunk| {
-            let mut word = [0u8; 8];
-            word[..chunk.len()].copy_from_slice(chunk);
-            u64::from_le_bytes(word).count_ones() as usize
-        })
-        .sum()
-}
-
-/// Reads only the presence bitset for a specific vector ID without loading vector payloads.
-pub fn read_vector_presence(
+fn open_vector_column(
     file_slice: &FileSlice,
     field: Field,
     vector_id: &str,
-) -> io::Result<Option<PresenceBitset>> {
+) -> io::Result<Option<VectorColumnReader>> {
     let mut reader = FileSliceCursor::new(file_slice);
     let magic = reader.read_u32()?;
     if magic != VECTOR_MAGIC {
@@ -221,28 +369,64 @@ pub fn read_vector_presence(
             let vector_name = &metadata[..id_end];
             let mut dims = [0u8; 4];
             dims.copy_from_slice(&metadata[id_end..dims_end]);
-            let dimensions = u32::from_le_bytes(dims) as usize;
+            let dimensions = u32::from_le_bytes(dims);
             let presence_bytes = &metadata[dims_end..];
+            let presence = PresenceBitset::from_bytes(presence_bytes, num_docs);
 
-            if field_id == target_field_id && vector_name == target_vector_id {
-                return Ok(Some(PresenceBitset::from_bytes(presence_bytes, num_docs)));
-            }
+            let quant_params = if encoding == VectorEncoding::Int8 {
+                Some(Int8QuantParams {
+                    scale: reader.read_f32()?,
+                    zero_point: reader.read_f32()?,
+                })
+            } else {
+                None
+            };
 
-            if encoding == VectorEncoding::Int8 {
-                reader.skip(8)?;
-            }
-
-            let vector_data_len = count_ones_in_bitset_bytes(presence_bytes)
-                .checked_mul(dimensions)
+            let vector_data_len = presence
+                .count_ones()
+                .try_into()
+                .ok()
+                .and_then(|count: usize| count.checked_mul(dimensions as usize))
                 .and_then(|count| count.checked_mul(bytes_per_dim))
                 .ok_or_else(|| {
                     io::Error::new(io::ErrorKind::InvalidData, "vector payload length overflow")
                 })?;
+
+            if field_id == target_field_id && vector_name == target_vector_id {
+                let data = file_slice.slice(reader.offset..reader.offset + vector_data_len);
+                return Ok(Some(VectorColumnReader {
+                    dimensions,
+                    presence,
+                    data,
+                    encoding,
+                    quant_params,
+                }));
+            }
+
             reader.skip(vector_data_len)?;
         }
     }
 
     Ok(None)
+}
+
+/// Reads only the presence bitset for a specific vector ID without loading vector payloads.
+pub fn read_vector_presence(
+    file_slice: &FileSlice,
+    field: Field,
+    vector_id: &str,
+) -> io::Result<Option<PresenceBitset>> {
+    Ok(open_vector_column(file_slice, field, vector_id)?.map(|column| column.presence))
+}
+
+/// Opens a lazy reader for a specific vector column without materializing the
+/// rest of the segment's vector payloads.
+pub fn open_vector_column_reader(
+    file_slice: &FileSlice,
+    field: Field,
+    vector_id: &str,
+) -> io::Result<Option<VectorColumnReader>> {
+    open_vector_column(file_slice, field, vector_id)
 }
 
 impl VectorReader {
@@ -652,6 +836,40 @@ mod tests {
 
         let missing = read_vector_presence(&file_slice, field, "missing").unwrap();
         assert!(missing.is_none());
+    }
+
+    #[test]
+    fn test_open_vector_column_reader_reads_only_requested_docs() {
+        let data = write_test_data();
+        let field = Field::from_field_id(0);
+        let file_slice = FileSlice::from(data);
+
+        let column = open_vector_column_reader(&file_slice, field, "summary")
+            .unwrap()
+            .expect("summary column should exist");
+
+        assert_eq!(column.dimensions(), 3);
+        assert_eq!(column.count(), 2);
+        assert!(column.has_vector(0));
+        assert!(!column.has_vector(1));
+        assert!(column.has_vector(2));
+
+        assert_eq!(column.get(1).unwrap(), None);
+        assert_eq!(
+            column.get(0).unwrap(),
+            Some(vec![10.0f32, 20.0, 30.0])
+        );
+        assert_eq!(
+            column.get(2).unwrap(),
+            Some(vec![40.0f32, 50.0, 60.0])
+        );
+
+        let batch = column.get_batch(&[2, 1, 0]).unwrap();
+        assert_eq!(batch, vec![
+            Some(vec![40.0f32, 50.0, 60.0]),
+            None,
+            Some(vec![10.0f32, 20.0, 30.0]),
+        ]);
     }
 
     #[test]

--- a/src/vector/reader.rs
+++ b/src/vector/reader.rs
@@ -15,9 +15,12 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::{self, Read};
 
+use common::HasLen;
+
 use super::format::{
     decode_vector, Int8QuantParams, PresenceBitset, VectorEncoding, VECTOR_MAGIC, VECTOR_VERSION,
 };
+use crate::directory::FileSlice;
 use crate::schema::Field;
 use crate::DocId;
 
@@ -88,6 +91,158 @@ pub struct VectorReader {
     num_docs: u32,
     /// Encoding used in this file
     encoding: VectorEncoding,
+}
+
+struct FileSliceCursor<'a> {
+    file_slice: &'a FileSlice,
+    offset: usize,
+    len: usize,
+}
+
+impl<'a> FileSliceCursor<'a> {
+    fn new(file_slice: &'a FileSlice) -> Self {
+        Self {
+            file_slice,
+            offset: 0,
+            len: file_slice.len(),
+        }
+    }
+
+    fn read_slice(&mut self, len: usize) -> io::Result<common::OwnedBytes> {
+        let end = self.offset.checked_add(len).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "vector file offset overflow")
+        })?;
+        if end > self.len {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "vector file ended before presence metadata could be read",
+            ));
+        }
+        let bytes = self.file_slice.read_bytes_slice(self.offset..end)?;
+        self.offset = end;
+        Ok(bytes)
+    }
+
+    fn read_u8(&mut self) -> io::Result<u8> {
+        Ok(self.read_slice(1)?[0])
+    }
+
+    fn read_u32(&mut self) -> io::Result<u32> {
+        let bytes = self.read_slice(4)?;
+        let mut raw = [0u8; 4];
+        raw.copy_from_slice(bytes.as_ref());
+        Ok(u32::from_le_bytes(raw))
+    }
+
+    fn skip(&mut self, len: usize) -> io::Result<()> {
+        let end = self.offset.checked_add(len).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "vector file offset overflow")
+        })?;
+        if end > self.len {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "vector file ended before vector payload could be skipped",
+            ));
+        }
+        self.offset = end;
+        Ok(())
+    }
+}
+
+fn count_ones_in_bitset_bytes(bytes: &[u8]) -> usize {
+    bytes
+        .chunks(8)
+        .map(|chunk| {
+            let mut word = [0u8; 8];
+            word[..chunk.len()].copy_from_slice(chunk);
+            u64::from_le_bytes(word).count_ones() as usize
+        })
+        .sum()
+}
+
+/// Reads only the presence bitset for a specific vector ID without loading vector payloads.
+pub fn read_vector_presence(
+    file_slice: &FileSlice,
+    field: Field,
+    vector_id: &str,
+) -> io::Result<Option<PresenceBitset>> {
+    let mut reader = FileSliceCursor::new(file_slice);
+    let magic = reader.read_u32()?;
+    if magic != VECTOR_MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "Invalid vector file magic: expected {:x}, got {:x}",
+                VECTOR_MAGIC, magic
+            ),
+        ));
+    }
+
+    let version = reader.read_u8()?;
+    if version != VECTOR_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Unsupported vector format version: {version}"),
+        ));
+    }
+
+    let encoding = VectorEncoding::from_u8(reader.read_u8()?)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "Unknown vector encoding"))?;
+
+    let num_fields = reader.read_u32()?;
+    let mut field_ids = Vec::with_capacity(num_fields as usize);
+    for _ in 0..num_fields {
+        field_ids.push(reader.read_u32()?);
+    }
+
+    let num_docs = reader.read_u32()?;
+    let bitset_len = num_docs.div_ceil(64) as usize * 8;
+    let target_field_id = field.field_id();
+    let target_vector_id = vector_id.as_bytes();
+    let bytes_per_dim = encoding.bytes_per_dim();
+
+    for field_id in field_ids {
+        let num_vector_ids = reader.read_u32()?;
+        for _ in 0..num_vector_ids {
+            let id_len = reader.read_u32()? as usize;
+            let metadata = reader.read_slice(
+                id_len
+                    .checked_add(4)
+                    .and_then(|len| len.checked_add(bitset_len))
+                    .ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "vector metadata length overflow",
+                        )
+                    })?,
+            )?;
+            let id_end = id_len;
+            let dims_end = id_end + 4;
+            let vector_name = &metadata[..id_end];
+            let mut dims = [0u8; 4];
+            dims.copy_from_slice(&metadata[id_end..dims_end]);
+            let dimensions = u32::from_le_bytes(dims) as usize;
+            let presence_bytes = &metadata[dims_end..];
+
+            if field_id == target_field_id && vector_name == target_vector_id {
+                return Ok(Some(PresenceBitset::from_bytes(presence_bytes, num_docs)));
+            }
+
+            if encoding == VectorEncoding::Int8 {
+                reader.skip(8)?;
+            }
+
+            let vector_data_len = count_ones_in_bitset_bytes(presence_bytes)
+                .checked_mul(dimensions)
+                .and_then(|count| count.checked_mul(bytes_per_dim))
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "vector payload length overflow")
+                })?;
+            reader.skip(vector_data_len)?;
+        }
+    }
+
+    Ok(None)
 }
 
 impl VectorReader {
@@ -365,6 +520,8 @@ mod tests {
     use super::*;
     use std::io::Cursor;
 
+    use crate::directory::FileSlice;
+
     fn write_test_data() -> Vec<u8> {
         let mut data = Vec::new();
 
@@ -477,6 +634,24 @@ mod tests {
         let field = Field::from_field_id(0);
         assert_eq!(reader.num_docs(), 0);
         assert!(reader.get(field, "any", 0).is_none());
+    }
+
+    #[test]
+    fn test_read_vector_presence_from_file_slice() {
+        let data = write_test_data();
+        let field = Field::from_field_id(0);
+        let file_slice = FileSlice::from(data);
+
+        let presence = read_vector_presence(&file_slice, field, "summary")
+            .unwrap()
+            .expect("presence bitset should exist");
+        assert_eq!(presence.count_ones(), 2);
+        assert!(presence.get(0));
+        assert!(!presence.get(1));
+        assert!(presence.get(2));
+
+        let missing = read_vector_presence(&file_slice, field, "missing").unwrap();
+        assert!(missing.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Quick way to enumerate doc ids that are present for a given vector field