### PR TITLE
Support opening a reader with a separate executor

### DIFF
--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -6,9 +6,10 @@ use crate::query::TermQuery;
 use crate::schema::{Field, IndexRecordOption, Schema, Type, INDEXED, STRING, TEXT};
 use crate::tokenizer::TokenizerManager;
 use crate::{
-    Directory, DocSet, Index, IndexBuilder, IndexReader, IndexSettings, IndexWriter, Postings,
-    ReloadPolicy, SegmentId, TantivyDocument, Term,
+    Directory, DocSet, Executor, Index, IndexBuilder, IndexReader, IndexSettings, IndexWriter,
+    Postings, ReloadPolicy, SegmentId, TantivyDocument, Term,
 };
+use std::sync::Arc;
 
 #[test]
 fn test_indexer_for_field() {
@@ -127,6 +128,25 @@ fn test_index_on_commit_reload_policy() -> crate::Result<()> {
         .unwrap();
     assert_eq!(reader.searcher().num_docs(), 0);
     test_index_on_commit_reload_policy_aux(field, &index, &reader)
+}
+
+#[test]
+fn test_reader_builder_with_executor_does_not_mutate_index() -> crate::Result<()> {
+    let index = Index::create_in_ram(throw_away_schema());
+    assert!(matches!(index.search_executor(), Executor::SingleThread));
+
+    let executor = Arc::new(Executor::multi_thread(2, "reader-builder-test-")?);
+    let reader = index
+        .reader_builder_with_executor(executor)?
+        .reload_policy(ReloadPolicy::Manual)
+        .try_into()?;
+
+    assert!(matches!(
+        reader.index().search_executor(),
+        Executor::ThreadPool(_)
+    ));
+    assert!(matches!(index.search_executor(), Executor::SingleThread));
+    Ok(())
 }
 
 #[cfg(feature = "mmap")]

--- a/src/index/index.rs
+++ b/src/index/index.rs
@@ -480,6 +480,31 @@ impl Index {
         IndexReaderBuilder::new(self.clone())
     }
 
+    /// Create a default [`IndexReader`] using a clone of this index configured
+    /// with the given search executor.
+    ///
+    /// This does not mutate this index's configured search executor.
+    pub fn reader_with_executor(
+        &self,
+        shared_thread_pool: Arc<Executor>,
+    ) -> crate::Result<IndexReader> {
+        self.reader_builder_with_executor(shared_thread_pool)?
+            .try_into()
+    }
+
+    /// Create an [`IndexReaderBuilder`] using a clone of this index configured
+    /// with the given search executor.
+    ///
+    /// This does not mutate this index's configured search executor.
+    pub fn reader_builder_with_executor(
+        &self,
+        shared_thread_pool: Arc<Executor>,
+    ) -> crate::Result<IndexReaderBuilder> {
+        let mut index = self.clone();
+        index.set_shared_multithread_executor(shared_thread_pool)?;
+        Ok(IndexReaderBuilder::new(index))
+    }
+
     /// Opens a new directory from an index path.
     #[cfg(feature = "mmap")]
     pub fn open_in_dir<P: AsRef<Path>>(directory_path: P) -> crate::Result<Index> {


### PR DESCRIPTION
This lets us avoid setting the executor on the index object directly