### PR TITLE
add back compat for vector maps

### DIFF
--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -396,7 +396,7 @@ impl SegmentWriter {
                         self.fieldnorms_writer.record(doc_id, field, num_vals);
                     }
                 }
-                FieldType::Artifact(_) => {}
+                FieldType::Artifact(_) | FieldType::VectorMap(_) => {}
             }
         }
         Ok(())

--- a/src/postings/per_field_postings_writer.rs
+++ b/src/postings/per_field_postings_writer.rs
@@ -69,6 +69,8 @@ fn posting_writer_from_field_entry(field_entry: &FieldEntry) -> Box<dyn Postings
                 JsonPostingsWriter::<DocIdRecorder>::default().into()
             }
         }
-        FieldType::Artifact(_) => Box::<SpecializedPostingsWriter<DocIdRecorder>>::default(),
+        FieldType::Artifact(_) | FieldType::VectorMap(_) => {
+            Box::<SpecializedPostingsWriter<DocIdRecorder>>::default()
+        }
     }
 }

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -509,9 +509,11 @@ impl QueryParser {
                 let ip_v6 = IpAddr::from_str(phrase)?.into_ipv6_addr();
                 Ok(Term::from_field_ip_addr(field, ip_v6))
             }
-            FieldType::Artifact(_) => Err(QueryParserError::UnsupportedQuery(
-                "Artifact fields cannot be queried with text queries.".to_string(),
-            )),
+            FieldType::Artifact(_) | FieldType::VectorMap(_) => {
+                Err(QueryParserError::UnsupportedQuery(
+                    "Artifact fields cannot be queried with text queries.".to_string(),
+                ))
+            }
         }
     }
 
@@ -612,9 +614,11 @@ impl QueryParser {
                 let term = Term::from_field_ip_addr(field, ip_v6);
                 Ok(vec![LogicalLiteral::Term(term)])
             }
-            FieldType::Artifact(_) => Err(QueryParserError::UnsupportedQuery(
-                "Artifact fields cannot be queried with text queries.".to_string(),
-            )),
+            FieldType::Artifact(_) | FieldType::VectorMap(_) => {
+                Err(QueryParserError::UnsupportedQuery(
+                    "Artifact fields cannot be queried with text queries.".to_string(),
+                ))
+            }
         }
     }
 

--- a/src/schema/field_entry.rs
+++ b/src/schema/field_entry.rs
@@ -87,6 +87,11 @@ impl FieldEntry {
         Self::new(field_name, FieldType::Artifact(artifact_options))
     }
 
+    /// Creates a field entry for a vector map field backed by artifacts.
+    pub fn new_vector_map(field_name: String, artifact_options: ArtifactOptions) -> FieldEntry {
+        Self::new(field_name, FieldType::VectorMap(artifact_options))
+    }
+
     /// Returns the name of the field
     pub fn name(&self) -> &str {
         &self.name
@@ -136,7 +141,7 @@ impl FieldEntry {
             FieldType::Bytes(ref options) => options.is_stored(),
             FieldType::JsonObject(ref options) => options.is_stored(),
             FieldType::IpAddr(ref options) => options.is_stored(),
-            FieldType::Artifact(_) => false,
+            FieldType::Artifact(_) | FieldType::VectorMap(_) => false,
         }
     }
 
@@ -150,7 +155,7 @@ impl FieldEntry {
 mod tests {
 
     use super::*;
-    use crate::schema::{Schema, TextFieldIndexing, TEXT};
+    use crate::schema::{ArtifactOptions, Schema, TextFieldIndexing, TEXT};
     use crate::Index;
 
     #[test]
@@ -209,6 +214,29 @@ mod tests {
             FieldType::Str(_) => {}
             _ => panic!("expected FieldType::Str"),
         }
+    }
+
+    #[test]
+    fn test_artifact_schema_type_names() {
+        let vector_entry =
+            FieldEntry::new_vector_map("vectors".to_string(), ArtifactOptions::default());
+        let vector_json = serde_json::to_value(&vector_entry).unwrap();
+        assert_eq!(vector_json["type"], "vector_map");
+        let vector_round_trip: FieldEntry = serde_json::from_value(vector_json).unwrap();
+        assert!(matches!(
+            vector_round_trip.field_type,
+            FieldType::VectorMap(_)
+        ));
+
+        let artifact_entry =
+            FieldEntry::new_artifact("generic_artifact".to_string(), ArtifactOptions::default());
+        let artifact_json = serde_json::to_value(&artifact_entry).unwrap();
+        assert_eq!(artifact_json["type"], "artifact");
+        let artifact_round_trip: FieldEntry = serde_json::from_value(artifact_json).unwrap();
+        assert!(matches!(
+            artifact_round_trip.field_type,
+            FieldType::Artifact(_)
+        ));
     }
 
     #[test]

--- a/src/schema/field_type.rs
+++ b/src/schema/field_type.rs
@@ -184,8 +184,11 @@ pub enum FieldType {
     /// IpAddr field
     IpAddr(IpAddrOptions),
     /// External per-segment artifact field.
-    #[serde(rename = "artifact", alias = "vector_map")]
+    #[serde(rename = "artifact")]
     Artifact(ArtifactOptions),
+    /// Vector map field backed by external per-segment artifacts.
+    #[serde(rename = "vector_map")]
+    VectorMap(ArtifactOptions),
 }
 
 impl FieldType {
@@ -202,7 +205,7 @@ impl FieldType {
             FieldType::Bytes(_) => Type::Bytes,
             FieldType::JsonObject(_) => Type::Json,
             FieldType::IpAddr(_) => Type::IpAddr,
-            FieldType::Artifact(_) => Type::Artifact,
+            FieldType::Artifact(_) | FieldType::VectorMap(_) => Type::Artifact,
         }
     }
 
@@ -229,7 +232,7 @@ impl FieldType {
             FieldType::Bytes(ref bytes_options) => bytes_options.is_indexed(),
             FieldType::JsonObject(ref json_object_options) => json_object_options.is_indexed(),
             FieldType::IpAddr(ref ip_addr_options) => ip_addr_options.is_indexed(),
-            FieldType::Artifact(_) => false,
+            FieldType::Artifact(_) | FieldType::VectorMap(_) => false,
         }
     }
 
@@ -267,7 +270,7 @@ impl FieldType {
             FieldType::IpAddr(ref ip_addr_options) => ip_addr_options.is_fast(),
             FieldType::Facet(_) => true,
             FieldType::JsonObject(ref json_object_options) => json_object_options.is_fast(),
-            FieldType::Artifact(_) => false,
+            FieldType::Artifact(_) | FieldType::VectorMap(_) => false,
         }
     }
 
@@ -287,7 +290,7 @@ impl FieldType {
             FieldType::Bytes(ref bytes_options) => bytes_options.fieldnorms(),
             FieldType::JsonObject(ref _json_object_options) => false,
             FieldType::IpAddr(ref ip_addr_options) => ip_addr_options.fieldnorms(),
-            FieldType::Artifact(_) => false,
+            FieldType::Artifact(_) | FieldType::VectorMap(_) => false,
         }
     }
 
@@ -339,13 +342,13 @@ impl FieldType {
                     None
                 }
             }
-            FieldType::Artifact(_) => None,
+            FieldType::Artifact(_) | FieldType::VectorMap(_) => None,
         }
     }
 
     /// Returns true if this field type is an artifact field.
     pub fn is_artifact(&self) -> bool {
-        matches!(self, FieldType::Artifact(_))
+        matches!(self, FieldType::Artifact(_) | FieldType::VectorMap(_))
     }
 
     /// Parses a field value from json, given the target FieldType.
@@ -446,10 +449,12 @@ impl FieldType {
 
                         Ok(OwnedValue::IpAddr(ip_addr.into_ipv6_addr()))
                     }
-                    FieldType::Artifact(_) => Err(ValueParsingError::TypeError {
-                        expected: "an external artifact",
-                        json: JsonValue::String(field_text),
-                    }),
+                    FieldType::Artifact(_) | FieldType::VectorMap(_) => {
+                        Err(ValueParsingError::TypeError {
+                            expected: "an external artifact",
+                            json: JsonValue::String(field_text),
+                        })
+                    }
                 }
             }
             JsonValue::Number(field_val_num) => match self {
@@ -509,10 +514,12 @@ impl FieldType {
                     expected: "a string with an ip addr",
                     json: JsonValue::Number(field_val_num),
                 }),
-                FieldType::Artifact(_) => Err(ValueParsingError::TypeError {
-                    expected: "an external artifact",
-                    json: JsonValue::Number(field_val_num),
-                }),
+                FieldType::Artifact(_) | FieldType::VectorMap(_) => {
+                    Err(ValueParsingError::TypeError {
+                        expected: "an external artifact",
+                        json: JsonValue::Number(field_val_num),
+                    })
+                }
             },
             JsonValue::Object(json_map) => match self {
                 FieldType::Str(_) => {
@@ -528,10 +535,12 @@ impl FieldType {
                     }
                 }
                 FieldType::JsonObject(_) => Ok(OwnedValue::from(json_map)),
-                FieldType::Artifact(_) => Err(ValueParsingError::TypeError {
-                    expected: "an external artifact",
-                    json: JsonValue::Object(json_map),
-                }),
+                FieldType::Artifact(_) | FieldType::VectorMap(_) => {
+                    Err(ValueParsingError::TypeError {
+                        expected: "an external artifact",
+                        json: JsonValue::Object(json_map),
+                    })
+                }
                 _ => Err(ValueParsingError::TypeError {
                     expected: self.value_type().name(),
                     json: JsonValue::Object(json_map),

--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -204,6 +204,16 @@ impl SchemaBuilder {
         self.add_field(field_entry)
     }
 
+    /// Adds a vector map field backed by artifacts to the schema.
+    pub fn add_vector_map_field<T: Into<ArtifactOptions>>(
+        &mut self,
+        field_name: &str,
+        field_options: T,
+    ) -> Field {
+        let field_entry = FieldEntry::new_vector_map(field_name.to_string(), field_options.into());
+        self.add_field(field_entry)
+    }
+
     /// Adds a field entry to the schema in build.
     pub fn add_field(&mut self, field_entry: FieldEntry) -> Field {
         let field = Field::from_field_id(self.fields.len() as u32);


### PR DESCRIPTION
Keep the vector map type, so that the upgrades are backwards compatible