### PR TITLE
Make segment manager warning debug

### DIFF
--- a/src/indexer/segment_manager.rs
+++ b/src/indexer/segment_manager.rs
@@ -31,7 +31,7 @@ impl SegmentRegisters {
         } else if self.committed.contains_all(segment_ids) {
             Some(SegmentsStatus::Committed)
         } else {
-            warn!(
+            debug!(
                 "segment_ids: {:?}, committed_ids: {:?}, uncommitted_ids {:?}",
                 segment_ids,
                 self.committed.segment_ids(),
@@ -193,7 +193,7 @@ impl SegmentManager {
         let segments_status = registers_lock
             .segments_status(before_merge_segment_ids)
             .ok_or_else(|| {
-                warn!("couldn't find segment in SegmentManager");
+                debug!("couldn't find segment in SegmentManager");
                 crate::TantivyError::InvalidArgument(
                     "The segments that were merged could not be found in the SegmentManager. This \
                      is not necessarily a bug, and can happen after a rollback for instance."


### PR DESCRIPTION
According to some AI exploration, this message starts appearing when we mix compaction and merging work:

What’s happening is likely Tantivy background merging. That setting makes the compact WAL writer run Tantivy’s own background merge policy. During compaction we also keep committing WAL batches that delete/re-add rows. Tantivy can start a merge for segments A+B, then a later commit/delete pass updates the in-memory SegmentManager and one of those segments is no longer present when the merge finishes. So end_merge() logs couldn't find segment in SegmentManager. Tantivy’s own error text says this case is “not necessarily a bug”; it’s a stale merge result.

So we demote the message to debug to reduce spam.